### PR TITLE
Add CLI train flag parsing

### DIFF
--- a/adversarial_autoencoder.py
+++ b/adversarial_autoencoder.py
@@ -2,6 +2,7 @@ import tensorflow as tf
 import numpy as np
 import datetime
 import os
+import argparse
 import matplotlib.pyplot as plt
 from matplotlib import gridspec
 from tensorflow.examples.tutorials.mnist import input_data
@@ -242,5 +243,16 @@ def train(train_model=True):
             saver.restore(sess, save_path=tf.train.latest_checkpoint(results_path + '/' + all_results[-1] + '/Saved_models/'))
             generate_image_grid(sess, op=decoder_image)
 
+def str2bool(v):
+    """Convert a string to boolean for argparse."""
+    if isinstance(v, bool):
+        return v
+    return v.lower() in ('true', '1', 'yes')
+
+
 if __name__ == '__main__':
-    train(train_model=True)
+    parser = argparse.ArgumentParser(description="Autoencoder Train Parameter")
+    parser.add_argument('--train', '-t', type=str2bool, default=True,
+                        help='Set to True to train a new model, False to load weights and display image grid')
+    args = parser.parse_args()
+    train(train_model=args.train)

--- a/autoencoder.py
+++ b/autoencoder.py
@@ -2,6 +2,7 @@ import tensorflow as tf
 import numpy as np
 import datetime
 import os
+import argparse
 import matplotlib.pyplot as plt
 from matplotlib import gridspec
 from tensorflow.examples.tutorials.mnist import input_data
@@ -185,5 +186,16 @@ def train(train_model):
                           save_path=tf.train.latest_checkpoint(results_path + '/' + all_results[-1] + '/Saved_models/'))
             generate_image_grid(sess, op=decoder_image)
 
+def str2bool(v):
+    """Convert a string to boolean for argparse."""
+    if isinstance(v, bool):
+        return v
+    return v.lower() in ('true', '1', 'yes')
+
+
 if __name__ == '__main__':
-    train(train_model=True)
+    parser = argparse.ArgumentParser(description="Autoencoder Train Parameter")
+    parser.add_argument('--train', '-t', type=str2bool, default=True,
+                        help='Set to True to train a new model, False to load weights and display image grid')
+    args = parser.parse_args()
+    train(train_model=args.train)

--- a/semi_supervised_adversarial_autoencoder.py
+++ b/semi_supervised_adversarial_autoencoder.py
@@ -354,9 +354,16 @@ def train(train_model=True):
             generate_image_grid(sess, op=decoder_image)
 
 
+def str2bool(v):
+    """Convert a string to boolean for argparse."""
+    if isinstance(v, bool):
+        return v
+    return v.lower() in ('true', '1', 'yes')
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Autoencoder Train Parameter")
-    parser.add_argument('--train', '-t', type=bool, default=True,
+    parser.add_argument('--train', '-t', type=str2bool, default=True,
                         help='Set to True to train a new model, False to load weights and display image grid')
     args = parser.parse_args()
     train(train_model=args.train)

--- a/supervised_adversarial_autoencoder.py
+++ b/supervised_adversarial_autoencoder.py
@@ -249,9 +249,16 @@ def train(train_model=True):
             generate_image_grid(sess, op=decoder_image)
 
 
+def str2bool(v):
+    """Convert a string to boolean for argparse."""
+    if isinstance(v, bool):
+        return v
+    return v.lower() in ('true', '1', 'yes')
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Autoencoder Train Parameter")
-    parser.add_argument('--train', '-t', type=bool, default=True,
+    parser.add_argument('--train', '-t', type=str2bool, default=True,
                         help='Set to True to train a new model, False to load weights and display image grid')
     args = parser.parse_args()
     train(train_model=args.train)


### PR DESCRIPTION
## Summary
- parse train flag correctly in autoencoder
- parse train flag correctly in adversarial autoencoder
- keep supervised and semi-supervised versions consistent

## Testing
- `python -m py_compile autoencoder.py adversarial_autoencoder.py supervised_adversarial_autoencoder.py semi_supervised_adversarial_autoencoder.py basic_nn_classifier.py`

------
https://chatgpt.com/codex/tasks/task_e_685633910c688325a4c358e5261e3566